### PR TITLE
Updated 5 CentOS 7 and 1 Ubuntu 20 for GCC 11+

### DIFF
--- a/alpine3_x86/Dockerfile
+++ b/alpine3_x86/Dockerfile
@@ -2,7 +2,7 @@ FROM i386/alpine:3.18
 
 LABEL org.opencontainers.image.authors="Evolved Binary Ltd <tech@evolvedbinary.com>"
 
-LABEL name="Alpine 3 (x64) RocksJava Build Environment" \
+LABEL name="Alpine 3 (x86) RocksJava Build Environment" \
   vendor="Evolved Binary Ltd"
 
 # make: Allow N jobs at once; infinite jobs with no arg

--- a/centos7_arm64v8/Dockerfile
+++ b/centos7_arm64v8/Dockerfile
@@ -36,13 +36,9 @@ RUN \
   && sed -i s%#baseurl=http://mirror.centos.org/altarch/\$releasever/%baseurl=https://vault.centos.org/altarch/7.9.2009/%g /etc/yum.repos.d/CentOS-fasttrack.repo \
   && yum --setopt=tsflags=nodocs -y update \
   && yum --setopt=tsflags=nodocs -y install epel-release \
-  && yum --setopt=tsflags=nodocs -y install centos-release-scl \
-  && sed -i s%mirrorlist=http%#mirrorlist=http%g /etc/yum.repos.d/CentOS-SCLo-scl.repo \
-  && sed -i s%mirrorlist=http%#mirrorlist=http%g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
-  && sed -i s%#\\sbaseurl=http://mirror.centos.org/centos/7/%baseurl=https://vault.centos.org/altarch/7.9.2009/%g /etc/yum.repos.d/CentOS-SCLo-scl.repo \
-  && sed -i s%#baseurl=http://mirror.centos.org/centos/7/%baseurl=https://vault.centos.org/altarch/7.9.2009/%g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
+  && echo -e '[c7-devtoolset-12]\nname=CentOS-7 - Devtoolset 12 (\$basearch)\nbaseurl=https://buildlogs.centos.org/c7-devtoolset-12.\$basearch/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/centos-buildlogs-aarch64.repo \
   && yum --setopt=tsflags=nodocs -y upgrade \
-  && yum --setopt=tsflags=nodocs -y install devtoolset-7 \
+  && yum --setopt=tsflags=nodocs -y install devtoolset-12 \
   && yum --setopt=tsflags=nodocs -y install make perl python3 which bzip2 wget \
   && yum --setopt=tsflags=nodocs -y install gettext-devel openssl openssl-devel zlib-devel expat-devel libssh2-devel jemalloc-devel \
   && yum -y clean all
@@ -54,9 +50,9 @@ RUN \
   wget https://github.com/nghttp2/nghttp2/releases/download/v$NGHTTP2_VERSION/nghttp2-$NGHTTP2_VERSION.tar.gz \
   && tar zxf nghttp2-$NGHTTP2_VERSION.tar.gz \
   && pushd nghttp2-$NGHTTP2_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-12 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
+  && scl enable devtoolset-12 'make -j $JOBS' \
+  && scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf nghttp2-$NGHTTP2_VERSION nghttp2-$NGHTTP2_VERSION.tar.gz
 
@@ -67,9 +63,9 @@ RUN \
   wget https://github.com/rockdaboot/libpsl/releases/download/$LIBPSL_VERSION/libpsl-$LIBPSL_VERSION.tar.gz \
   && tar zxf libpsl-$LIBPSL_VERSION.tar.gz \
   && pushd libpsl-$LIBPSL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-12 './configure --prefix=/usr' \
+  && scl enable devtoolset-12 'make -j $JOBS' \
+  && scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf libpsl-$LIBPSL_VERSION libpsl-$LIBPSL_VERSION.tar.gz
 
@@ -98,9 +94,9 @@ RUN \
   && wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.gz \
   && tar zxf curl-$CURL_VERSION.tar.gz \
   && pushd curl-$CURL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-12 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
+  && scl enable devtoolset-12 'make -j $JOBS' \
+  && scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf curl-$CURL_VERSION curl-$CURL_VERSION.tar.gz
 
@@ -146,10 +142,10 @@ RUN \
   && wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.gz \
   && tar zxf git-$GIT_VERSION.tar.gz \
   && pushd git-$GIT_VERSION \
-  && scl enable devtoolset-7 'make configure' \
-  && scl enable devtoolset-7 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS all' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-12 'make configure' \
+  && scl enable devtoolset-12 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
+  && scl enable devtoolset-12 'make -j $JOBS all' \
+  && scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf git-$GIT_VERSION git-$GIT_VERSION.tar.gz
 
@@ -201,18 +197,18 @@ RUN \
   && wget https://cmake.org/files/v$CMAKE_VERSION_SHORT/cmake-$CMAKE_VERSION.tar.gz \
   && tar zxvf cmake-$CMAKE_VERSION.tar.gz \
   && pushd cmake-$CMAKE_VERSION \
-  && scl enable devtoolset-7 './bootstrap --system-curl' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-12 './bootstrap --system-curl' \
+  && scl enable devtoolset-12 'make -j $JOBS' \
+  && scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf cmake-$CMAKE_VERSION cmake-$CMAKE_VERSION.tar.gz \
   && wget -O gflags-$GFLAGS_VERSION.tar.gz https://github.com/gflags/gflags/archive/refs/tags/v$GFLAGS_VERSION.tar.gz \
   && tar zxvf gflags-$GFLAGS_VERSION.tar.gz \
   && mkdir gflags-$GFLAGS_VERSION/build \
   && pushd gflags-$GFLAGS_VERSION/build \
-  && scl enable devtoolset-7 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-12 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
+  && scl enable devtoolset-12 'make -j $JOBS' \
+  && scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf gflags-$GFLAGS_VERSION gflags-$GFLAGS_VERSION.tar.gz
 

--- a/centos7_arm64v8/bellsoft.repo
+++ b/centos7_arm64v8/bellsoft.repo
@@ -7,3 +7,4 @@ enabled=1
 gpgcheck=1
 gpgkey=https://download.bell-sw.com/pki/GPG-KEY-bellsoft
 priority=1
+sslverify=0

--- a/centos7_ppc64le/Dockerfile
+++ b/centos7_ppc64le/Dockerfile
@@ -42,7 +42,7 @@ RUN \
   && sed -i s%#\\sbaseurl=http://mirror.centos.org/centos/7/%baseurl=https://vault.centos.org/altarch/7.9.2009/%g /etc/yum.repos.d/CentOS-SCLo-scl.repo \
   && sed -i s%#baseurl=http://mirror.centos.org/centos/7/%baseurl=https://vault.centos.org/altarch/7.9.2009/%g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
   && yum --setopt=tsflags=nodocs -y upgrade \
-  && yum --setopt=tsflags=nodocs -y install devtoolset-7 \
+  && yum --setopt=tsflags=nodocs -y install devtoolset-11 \
   && yum --setopt=tsflags=nodocs -y install make perl python3 which bzip2 wget \
   && yum --setopt=tsflags=nodocs -y install gettext-devel openssl openssl-devel zlib-devel expat-devel libssh2-devel jemalloc-devel  \
   && yum -y clean all
@@ -54,9 +54,9 @@ RUN \
   wget https://github.com/nghttp2/nghttp2/releases/download/v$NGHTTP2_VERSION/nghttp2-$NGHTTP2_VERSION.tar.gz \
   && tar zxf nghttp2-$NGHTTP2_VERSION.tar.gz \
   && pushd nghttp2-$NGHTTP2_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf nghttp2-$NGHTTP2_VERSION nghttp2-$NGHTTP2_VERSION.tar.gz
 
@@ -67,9 +67,9 @@ RUN \
   wget https://github.com/rockdaboot/libpsl/releases/download/$LIBPSL_VERSION/libpsl-$LIBPSL_VERSION.tar.gz \
   && tar zxf libpsl-$LIBPSL_VERSION.tar.gz \
   && pushd libpsl-$LIBPSL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf libpsl-$LIBPSL_VERSION libpsl-$LIBPSL_VERSION.tar.gz
 
@@ -98,9 +98,9 @@ RUN \
   && wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.gz \
   && tar zxf curl-$CURL_VERSION.tar.gz \
   && pushd curl-$CURL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf curl-$CURL_VERSION curl-$CURL_VERSION.tar.gz
 
@@ -146,10 +146,10 @@ RUN \
   && wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.gz \
   && tar zxf git-$GIT_VERSION.tar.gz \
   && pushd git-$GIT_VERSION \
-  && scl enable devtoolset-7 'make configure' \
-  && scl enable devtoolset-7 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS all' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 'make configure' \
+  && scl enable devtoolset-11 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
+  && scl enable devtoolset-11 'make -j $JOBS all' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf git-$GIT_VERSION git-$GIT_VERSION.tar.gz
 
@@ -201,18 +201,18 @@ RUN \
   && wget https://cmake.org/files/v$CMAKE_VERSION_SHORT/cmake-$CMAKE_VERSION.tar.gz \
   && tar zxvf cmake-$CMAKE_VERSION.tar.gz \
   && pushd cmake-$CMAKE_VERSION \
-  && scl enable devtoolset-7 './bootstrap --system-curl' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './bootstrap --system-curl' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf cmake-$CMAKE_VERSION cmake-$CMAKE_VERSION.tar.gz \
   && wget -O gflags-$GFLAGS_VERSION.tar.gz https://github.com/gflags/gflags/archive/refs/tags/v$GFLAGS_VERSION.tar.gz \
   && tar zxvf gflags-$GFLAGS_VERSION.tar.gz \
   && mkdir gflags-$GFLAGS_VERSION/build \
   && pushd gflags-$GFLAGS_VERSION/build \
-  && scl enable devtoolset-7 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf gflags-$GFLAGS_VERSION gflags-$GFLAGS_VERSION.tar.gz
 

--- a/centos7_ppc64le/bellsoft.repo
+++ b/centos7_ppc64le/bellsoft.repo
@@ -7,3 +7,4 @@ enabled=1
 gpgcheck=1
 gpgkey=https://download.bell-sw.com/pki/GPG-KEY-bellsoft
 priority=1
+sslverify=0

--- a/centos7_s390x/Dockerfile
+++ b/centos7_s390x/Dockerfile
@@ -36,7 +36,7 @@ RUN \
   yum --setopt=tsflags=nodocs -y update \
   && yum -y install centos-release-scl-rh \
   && yum --setopt=tsflags=nodocs -y upgrade \
-  && yum --setopt=tsflags=nodocs -y install devtoolset-7 \
+  && yum --setopt=tsflags=nodocs -y install devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-binutils devtoolset-11-runtime \
   && yum --setopt=tsflags=nodocs -y install make perl python3 which bzip2 wget \
   && yum --setopt=tsflags=nodocs -y install gettext-devel openssl openssl-devel zlib-devel expat-devel libssh2-devel jemalloc-devel \
   && yum -y clean all
@@ -48,9 +48,9 @@ RUN \
   wget https://github.com/nghttp2/nghttp2/releases/download/v$NGHTTP2_VERSION/nghttp2-$NGHTTP2_VERSION.tar.gz \
   && tar zxf nghttp2-$NGHTTP2_VERSION.tar.gz \
   && pushd nghttp2-$NGHTTP2_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf nghttp2-$NGHTTP2_VERSION nghttp2-$NGHTTP2_VERSION.tar.gz
 
@@ -61,9 +61,9 @@ RUN \
   wget https://github.com/rockdaboot/libpsl/releases/download/$LIBPSL_VERSION/libpsl-$LIBPSL_VERSION.tar.gz \
   && tar zxf libpsl-$LIBPSL_VERSION.tar.gz \
   && pushd libpsl-$LIBPSL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf libpsl-$LIBPSL_VERSION libpsl-$LIBPSL_VERSION.tar.gz
 
@@ -92,9 +92,9 @@ RUN \
   && wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.gz \
   && tar zxf curl-$CURL_VERSION.tar.gz \
   && pushd curl-$CURL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf curl-$CURL_VERSION curl-$CURL_VERSION.tar.gz
 
@@ -140,10 +140,10 @@ RUN \
   && wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.gz \
   && tar zxf git-$GIT_VERSION.tar.gz \
   && pushd git-$GIT_VERSION \
-  && scl enable devtoolset-7 'make configure' \
-  && scl enable devtoolset-7 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS all' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 'make configure' \
+  && scl enable devtoolset-11 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
+  && scl enable devtoolset-11 'make -j $JOBS all' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf git-$GIT_VERSION git-$GIT_VERSION.tar.gz
 
@@ -194,18 +194,18 @@ RUN \
   && wget https://cmake.org/files/v$CMAKE_VERSION_SHORT/cmake-$CMAKE_VERSION.tar.gz \
   && tar zxvf cmake-$CMAKE_VERSION.tar.gz \
   && pushd cmake-$CMAKE_VERSION \
-  && scl enable devtoolset-7 './bootstrap --system-curl' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './bootstrap --system-curl' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf cmake-$CMAKE_VERSION cmake-$CMAKE_VERSION.tar.gz \
   && wget -O gflags-$GFLAGS_VERSION.tar.gz https://github.com/gflags/gflags/archive/refs/tags/v$GFLAGS_VERSION.tar.gz \
   && tar zxvf gflags-$GFLAGS_VERSION.tar.gz \
   && mkdir gflags-$GFLAGS_VERSION/build \
   && pushd gflags-$GFLAGS_VERSION/build \
-  && scl enable devtoolset-7 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf gflags-$GFLAGS_VERSION gflags-$GFLAGS_VERSION.tar.gz
 

--- a/centos7_x64/Dockerfile
+++ b/centos7_x64/Dockerfile
@@ -42,7 +42,7 @@ RUN \
   && sed -i s%#\\sbaseurl=http://mirror.centos.org/centos/7/%baseurl=https://vault.centos.org/7.9.2009/%g /etc/yum.repos.d/CentOS-SCLo-scl.repo \
   && sed -i s%#baseurl=http://mirror.centos.org/centos/7/%baseurl=https://vault.centos.org/7.9.2009/%g /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
   && yum --setopt=tsflags=nodocs -y upgrade \
-  && yum --setopt=tsflags=nodocs -y install devtoolset-7 \
+  && yum --setopt=tsflags=nodocs -y install devtoolset-11 \
   && yum --setopt=tsflags=nodocs -y install make perl python3 which bzip2 wget \
   && yum --setopt=tsflags=nodocs -y install gettext-devel openssl openssl-devel zlib-devel expat-devel libssh2-devel jemalloc-devel \
   && yum -y clean all
@@ -54,9 +54,9 @@ RUN \
   wget https://github.com/nghttp2/nghttp2/releases/download/v$NGHTTP2_VERSION/nghttp2-$NGHTTP2_VERSION.tar.gz \
   && tar zxf nghttp2-$NGHTTP2_VERSION.tar.gz \
   && pushd nghttp2-$NGHTTP2_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf nghttp2-$NGHTTP2_VERSION nghttp2-$NGHTTP2_VERSION.tar.gz
 
@@ -67,9 +67,9 @@ RUN \
   wget https://github.com/rockdaboot/libpsl/releases/download/$LIBPSL_VERSION/libpsl-$LIBPSL_VERSION.tar.gz \
   && tar zxf libpsl-$LIBPSL_VERSION.tar.gz \
   && pushd libpsl-$LIBPSL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf libpsl-$LIBPSL_VERSION libpsl-$LIBPSL_VERSION.tar.gz
 
@@ -98,9 +98,9 @@ RUN \
   && wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.gz \
   && tar zxf curl-$CURL_VERSION.tar.gz \
   && pushd curl-$CURL_VERSION \
-  && scl enable devtoolset-7 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf curl-$CURL_VERSION curl-$CURL_VERSION.tar.gz
 
@@ -146,10 +146,10 @@ RUN \
   && wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.gz \
   && tar zxf git-$GIT_VERSION.tar.gz \
   && pushd git-$GIT_VERSION \
-  && scl enable devtoolset-7 'make configure' \
-  && scl enable devtoolset-7 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
-  && scl enable devtoolset-7 'make -j $JOBS all' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 'make configure' \
+  && scl enable devtoolset-11 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
+  && scl enable devtoolset-11 'make -j $JOBS all' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf git-$GIT_VERSION git-$GIT_VERSION.tar.gz
 
@@ -201,18 +201,18 @@ RUN \
   && wget https://cmake.org/files/v$CMAKE_VERSION_SHORT/cmake-$CMAKE_VERSION.tar.gz \
   && tar zxvf cmake-$CMAKE_VERSION.tar.gz \
   && pushd cmake-$CMAKE_VERSION \
-  && scl enable devtoolset-7 './bootstrap --system-curl' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 './bootstrap --system-curl' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf cmake-$CMAKE_VERSION cmake-$CMAKE_VERSION.tar.gz \
   && wget -O gflags-$GFLAGS_VERSION.tar.gz https://github.com/gflags/gflags/archive/refs/tags/v$GFLAGS_VERSION.tar.gz \
   && tar zxvf gflags-$GFLAGS_VERSION.tar.gz \
   && mkdir gflags-$GFLAGS_VERSION/build \
   && pushd gflags-$GFLAGS_VERSION/build \
-  && scl enable devtoolset-7 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
-  && scl enable devtoolset-7 'make -j $JOBS' \
-  && scl enable devtoolset-7 'make install' \
+  && scl enable devtoolset-11 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
+  && scl enable devtoolset-11 'make -j $JOBS' \
+  && scl enable devtoolset-11 'make install' \
   && popd \
   && rm -rf gflags-$GFLAGS_VERSION gflags-$GFLAGS_VERSION.tar.gz
 

--- a/centos7_x64/bellsoft.repo
+++ b/centos7_x64/bellsoft.repo
@@ -7,3 +7,4 @@ enabled=1
 gpgcheck=1
 gpgkey=https://download.bell-sw.com/pki/GPG-KEY-bellsoft
 priority=1
+sslverify=0

--- a/centos7_x86/CentOS-buildlogs-devtoolset-12.repo
+++ b/centos7_x86/CentOS-buildlogs-devtoolset-12.repo
@@ -1,12 +1,13 @@
-# CentOS-buildlogs-devtoolset-8.repo
+# CentOS-buildlogs-devtoolset-12.repo
 #
 # Please see https://www.mail-archive.com/centos@centos.org/msg133717.html
 # for more information
 
-[centos-buildlogs-devtoolset-8]
-name=CentOS-7 - buildlogs devtoolset-8
-baseurl=https://buildlogs.centos.org/c7-devtoolset-8.x86_64/
+[centos-buildlogs-devtoolset-12]
+name=CentOS-7 - buildlogs devtoolset-12
+baseurl=https://buildlogs.centos.org/c7-devtoolset-12.x86_64/
 #mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=6&repo=sclo-sclo
 gpgcheck=0
 enabled=1
 gpgkey=
+

--- a/centos7_x86/Dockerfile
+++ b/centos7_x86/Dockerfile
@@ -32,7 +32,7 @@ ARG GFLAGS_VERSION=2.2.2
 
 
 # 1. Build a base CentOS 7 Build Environment
-COPY CentOS-buildlogs-devtoolset-8.repo /etc/yum.repos.d/CentOS-buildlogs-devtoolset-8.repo
+COPY CentOS-buildlogs-devtoolset-12.repo /etc/yum.repos.d/CentOS-buildlogs-devtoolset-12.repo
 RUN \
   sed -i s%mirrorlist=http%#mirrorlist=http%g /etc/yum.repos.d/CentOS-Base.repo \
   && sed -i s%mirrorlist=http%#mirrorlist=http%g /etc/yum.repos.d/CentOS-fasttrack.repo \
@@ -40,16 +40,16 @@ RUN \
   && sed -i s%#baseurl=http://mirror.centos.org/altarch/\$releasever/%baseurl=https://vault.centos.org/altarch/7.9.2009/%g /etc/yum.repos.d/CentOS-fasttrack.repo \
   && linux32 yum --setopt=tsflags=nodocs -y update \
   && linux32 yum --setopt=tsflags=nodocs -y upgrade \
-  && linux32 yum --setopt=tsflags=nodocs -y install devtoolset-8 \
+  && linux32 yum --setopt=tsflags=nodocs -y install devtoolset-12 \
   && linux32 yum --setopt=tsflags=nodocs -y install make perl python3 which bzip2 wget \
   && linux32 yum --setopt=tsflags=nodocs -y install gettext-devel openssl openssl-devel zlib-devel expat-devel libssh2-devel \
   && linux32 yum -y clean all \
   && wget https://github.com/jemalloc/jemalloc/releases/download/$JEMALLOC_VERSION/jemalloc-$JEMALLOC_VERSION.tar.bz2 \
   && tar jxvf jemalloc-$JEMALLOC_VERSION.tar.bz2 \
   && pushd jemalloc-$JEMALLOC_VERSION \ 
-  && linux32 scl enable devtoolset-8 './configure --prefix=/usr' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 './configure --prefix=/usr' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf jemalloc-$JEMALLOC_VERSION jemalloc-$JEMALLOC_VERSION.tar.bz2
 
@@ -60,9 +60,9 @@ RUN \
   wget https://github.com/nghttp2/nghttp2/releases/download/v$NGHTTP2_VERSION/nghttp2-$NGHTTP2_VERSION.tar.gz \
   && tar zxf nghttp2-$NGHTTP2_VERSION.tar.gz \
   && pushd nghttp2-$NGHTTP2_VERSION \
-  && linux32 scl enable devtoolset-8 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 './configure --prefix=/usr --with-openssl --with-zlib --with-jemalloc --enable-lib-only' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf nghttp2-$NGHTTP2_VERSION nghttp2-$NGHTTP2_VERSION.tar.gz
 
@@ -73,9 +73,9 @@ RUN \
   wget https://github.com/rockdaboot/libpsl/releases/download/$LIBPSL_VERSION/libpsl-$LIBPSL_VERSION.tar.gz \
   && tar zxf libpsl-$LIBPSL_VERSION.tar.gz \
   && pushd libpsl-$LIBPSL_VERSION \
-  && linux32 scl enable devtoolset-8 './configure --prefix=/usr' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 './configure --prefix=/usr' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf libpsl-$LIBPSL_VERSION libpsl-$LIBPSL_VERSION.tar.gz
 
@@ -104,9 +104,9 @@ RUN \
   && wget https://curl.haxx.se/download/curl-$CURL_VERSION.tar.gz \
   && tar zxf curl-$CURL_VERSION.tar.gz \
   && pushd curl-$CURL_VERSION \
-  && linux32 scl enable devtoolset-8 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 './configure --prefix=/usr --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf curl-$CURL_VERSION curl-$CURL_VERSION.tar.gz
 
@@ -135,7 +135,7 @@ RUN \
   && ln -s libnghttp2.so.14.28.5 libnghttp2.so.14 \
   && ln -s libpsl.so.5.3.5 libpsl.so \
   && ln -s libpsl.so.5.3.5 libpsl.so.5 \
-  #&& unlink libcurl.so \
+  && unlink libcurl.so \
   && unlink libcurl.so.4 \
   && rm libcurl.so.4.3.0 \
   && ln -s libcurl.so.4.8.0 libcurl.so \
@@ -146,10 +146,10 @@ RUN \
   && wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.gz \
   && tar zxf git-$GIT_VERSION.tar.gz \
   && pushd git-$GIT_VERSION \
-  && linux32 scl enable devtoolset-8 'make configure' \
-  && linux32 scl enable devtoolset-8 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS all' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 'make configure' \
+  && linux32 scl enable devtoolset-12 'NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease ./configure --prefix=/usr' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS all' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf git-$GIT_VERSION git-$GIT_VERSION.tar.gz
 
@@ -183,7 +183,7 @@ RUN \
   && ln -s libnghttp2.so.14.28.5 libnghttp2.so.14 \
   && ln -s libpsl.so.5.3.5 libpsl.so \
   && ln -s libpsl.so.5.3.5 libpsl.so.5 \
-  #&& unlink libcurl.so \
+  && unlink libcurl.so \
   && unlink libcurl.so.4 \
   && rm libcurl.so.4.3.0 \
   && ln -s libcurl.so.4.8.0 libcurl.so \
@@ -196,18 +196,18 @@ RUN \
   && wget https://cmake.org/files/v$CMAKE_VERSION_SHORT/cmake-$CMAKE_VERSION.tar.gz \
   && tar zxvf cmake-$CMAKE_VERSION.tar.gz \
   && pushd cmake-$CMAKE_VERSION \
-  && linux32 scl enable devtoolset-8 './bootstrap --system-curl' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 './bootstrap --system-curl' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf cmake-$CMAKE_VERSION cmake-$CMAKE_VERSION.tar.gz \
   && wget -O gflags-$GFLAGS_VERSION.tar.gz https://github.com/gflags/gflags/archive/refs/tags/v$GFLAGS_VERSION.tar.gz \
   && tar zxvf gflags-$GFLAGS_VERSION.tar.gz \
   && mkdir gflags-$GFLAGS_VERSION/build \
   && pushd gflags-$GFLAGS_VERSION/build \
-  && linux32 scl enable devtoolset-8 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
-  && linux32 scl enable devtoolset-8 'make -j $JOBS' \
-  && linux32 scl enable devtoolset-8 'make install' \
+  && linux32 scl enable devtoolset-12 'CMAKE_INSTALL_PREFIX=/usr cmake ..' \
+  && linux32 scl enable devtoolset-12 'make -j $JOBS' \
+  && linux32 scl enable devtoolset-12 'make install' \
   && popd \
   && rm -rf gflags-$GFLAGS_VERSION gflags-$GFLAGS_VERSION.tar.gz
 

--- a/centos7_x86/bellsoft.repo
+++ b/centos7_x86/bellsoft.repo
@@ -7,3 +7,4 @@ enabled=1
 gpgcheck=1
 gpgkey=https://download.bell-sw.com/pki/GPG-KEY-bellsoft
 priority=1
+sslverify=0

--- a/ubuntu20_riscv64/Dockerfile
+++ b/ubuntu20_riscv64/Dockerfile
@@ -7,8 +7,13 @@ LABEL name="Ubuntu 20.04 (riscv64) RocksJava Build Environment" \
 
 RUN apt-get -y update \
   && apt-get -y dist-upgrade \
+  && apt-get -y install software-properties-common \
+  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+  && apt-get -y update \
   && apt-get -y install cmake \
-  && apt-get -y install g++ make perl \
+  && apt-get -y install gcc-11 g++-11 make perl \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
+  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100 \
   && apt-get -y install libjemalloc-dev zlib1g-dev libbz2-dev liblz4-dev libsnappy-dev libzstd-dev libgflags-dev \
   && apt-get -y install openssl openjdk-11-jdk-headless wget curl
 


### PR DESCRIPTION
- centOS 7 x86 to use devtoolset-12, because 11 is not available here.
- centOS 7 x64 to use devtoolset-11.
- centOS 7 ppc64le to 11, tested on this machine.
- centOS 7 arm64v8 to 12, but it is not from official SCLO, just buildlogs.
- centOS 7 s390x to 11, with limited 11 packages
- ubuntu20 to 11, current 20.04 would be okay but need to install and use gcc, g++ 11